### PR TITLE
`cd` to project root before running scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Available commands:
 ```
 
 Now run, for example, `, fmt` to run the corresponding script.
+
+The scripts will be run *always* from the project root directory[^flake-root] regardless of the current working directory.
+
+[^flake-root]: "Project root directory" is determined by traversing the directory up until we find the unique file that exists only at the root. This unique file is `flake.nix` by default, which can be overridden using the [flake-root](https://github.com/srid/flake-root) module. 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Now run, for example, `, fmt` to run the corresponding script.
 
 The scripts will be run *always* from the project root directory[^flake-root] regardless of the current working directory.
 
-[^flake-root]: "Project root directory" is determined by traversing the directory up until we find the unique file that exists only at the root. This unique file is `flake.nix` by default, which can be overridden using the [flake-root](https://github.com/srid/flake-root) module. 
+[^flake-root]: "Project root directory" is determined by traversing the directory up until we find the unique file that exists only at the root. This unique file is `flake.nix` by default, which can be overridden using the [flake-root](https://github.com/srid/flake-root) module; i.e.; `flake-root.projectRootFile = "stack.yaml";`

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,15 @@
   "nodes": {
     "flake-root": {
       "locked": {
-        "lastModified": 1671294861,
-        "narHash": "sha256-vYyAp276tw0fdm5f/T7AwpRB38gawQgs7Id7a35uiwo=",
+        "lastModified": 1671295174,
+        "narHash": "sha256-5K+wdsB5TYSmI6HeexOMvJTZTBdXb9RbiFwXRtQkE3M=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "fc9ba33e216341b607a850f4c7e2e2d6c1baa4ad",
+        "rev": "bb96b89f65d7c47457303f2385798a09f4a1dd5a",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "init",
         "repo": "flake-root",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "flake-root": {
+      "locked": {
+        "lastModified": 1671292390,
+        "narHash": "sha256-AFPFCAs6LHhIqTlbe07a2QK0moxTVOwo8Bm/MxH7vVA=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "dac361dd5703a51ef27e9db5bdcf005be225b576",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "init",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-root": "flake-root"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-root": {
       "locked": {
-        "lastModified": 1671292390,
-        "narHash": "sha256-AFPFCAs6LHhIqTlbe07a2QK0moxTVOwo8Bm/MxH7vVA=",
+        "lastModified": 1671294861,
+        "narHash": "sha256-vYyAp276tw0fdm5f/T7AwpRB38gawQgs7Id7a35uiwo=",
         "owner": "srid",
         "repo": "flake-root",
-        "rev": "dac361dd5703a51ef27e9db5bdcf005be225b576",
+        "rev": "fc9ba33e216341b607a850f4c7e2e2d6c1baa4ad",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     flake-root.url = "github:srid/flake-root/init";
   };
-  outputs = { self, ... }: {
-    flakeModule = ./nix/flake-module.nix;
+  outputs = { self, flake-root, ... }: {
+    flakeModule = import ./nix/flake-module.nix { inherit flake-root; };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A `flake-parts` module for your Nix devshell scripts";
   inputs = {
-    flake-root.url = "github:srid/flake-root/init";
+    flake-root.url = "github:srid/flake-root";
   };
   outputs = { self, flake-root, ... }: {
     flakeModule = import ./nix/flake-module.nix { inherit flake-root; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,8 @@
 {
   description = "A `flake-parts` module for your Nix devshell scripts";
+  inputs = {
+    flake-root.url = "github:srid/flake-root";
+  };
   outputs = { self, ... }: {
     flakeModule = ./nix/flake-module.nix;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A `flake-parts` module for your Nix devshell scripts";
   inputs = {
-    flake-root.url = "github:srid/flake-root";
+    flake-root.url = "github:srid/flake-root/init";
   };
   outputs = { self, ... }: {
     flakeModule = ./nix/flake-module.nix;

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,4 +1,4 @@
-{ self, lib, flake-parts-lib, ... }:
+{ self, lib, inputs, flake-parts-lib, ... }:
 let
   inherit (flake-parts-lib)
     mkPerSystemOption;
@@ -7,6 +7,9 @@ let
     types;
 in
 {
+  imports = [
+    inputs.flake-root.flakeModule
+  ];
   options = {
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }:
@@ -58,7 +61,11 @@ in
                 '';
                 default = shell: shell.overrideAttrs (oa:
                   let
-                    wrapper = import ./wrapper.nix { inherit pkgs lib; inherit (config) mission-control; };
+                    wrapper = import ./wrapper.nix {
+                      inherit pkgs lib;
+                      inherit (config) mission-control;
+                      flake-root = config.flake-root.package;
+                    };
                     banner = import ./banner.nix { inherit wrapper; inherit (config.mission-control) wrapperName; };
                   in
                   {

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,4 +1,5 @@
-{ self, lib, inputs, flake-parts-lib, ... }:
+{ flake-root }:
+{ self, lib, flake-parts-lib, ... }:
 let
   inherit (flake-parts-lib)
     mkPerSystemOption;
@@ -8,7 +9,7 @@ let
 in
 {
   imports = [
-    inputs.flake-root.flakeModule
+    flake-root.flakeModule
   ];
   options = {
     perSystem = mkPerSystemOption

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -36,8 +36,9 @@ let
           showHelp
           exit 1
         else 
+          FLAKE_ROOT="''$(${lib.getExe flake-root})"
           set -x
-          cd "${lib.getExe flake-root}"
+          cd "$FLAKE_ROOT"
           exec "$@"
         fi
       '';

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -37,7 +37,6 @@ let
           exit 1
         else 
           FLAKE_ROOT="''$(${lib.getExe flake-root})"
-          set -x
           cd "$FLAKE_ROOT"
           exec "$@"
         fi

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, mission-control, ... }:
+{ pkgs, lib, mission-control, flake-root, ... }:
 
 let
   mkCommand = name: v:
@@ -15,7 +15,6 @@ let
     pkgs.writeShellApplication {
       name = mission-control.wrapperName;
       runtimeInputs = commands;
-      # TODO: find_up!
       text = ''
         showHelp () {
           echo -e "Available commands:\n"
@@ -37,6 +36,8 @@ let
           showHelp
           exit 1
         else 
+          set -x
+          cd "${lib.getExe flake-root}"
           exec "$@"
         fi
       '';


### PR DESCRIPTION
Uses https://github.com/srid/flake-root

This ensures that running `, foo` will work regardless if the dev is in project root or some other sub directory.