### PR TITLE
flake-module.nix: Identify module with _file

### DIFF
--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -8,6 +8,7 @@ let
     types;
 in
 {
+  _file = __curPos.file;
   imports = [
     flake-root.flakeModule
   ];


### PR DESCRIPTION
The documentation tooling needs locations in order to split the docs into pages.

This means that the  module system needs to see a file name at some point, which usually happens by importing a path. This `flake-module.nix` is technically not a module, but a function to an anonymous module.
Hence, we need to remind the module system of the location.