### PR TITLE
Require explicit importing of `flake-root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once you are in the dev shell, you can run any of these scripts prefixed with th
 
 The scripts will be run *always* from the project root directory[^flake-root] regardless of the current working directory.
 
-[^flake-root]: "Project root directory" is determined by traversing the directory up until we find the unique file that exists only at the root. This unique file is `flake.nix` by default, which can be overridden using the [flake-root](https://github.com/srid/flake-root) module; i.e.; `flake-root.projectRootFile = "stack.yaml";`
+[^flake-root]: "Project root directory" is determined by traversing the directory up until we find the unique file that exists only at the root. This unique file is `flake.nix` by default, which can be overridden using the [flake-root](https://github.com/srid/flake-root) module that this module mandatorily requires; i.e.; `flake-root.projectRootFile = "stack.yaml";`
 
 ## Examples
 

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -20,6 +20,21 @@
     },
     "flake-root": {
       "locked": {
+        "lastModified": 1671378805,
+        "narHash": "sha256-yqGxyzMN2GuppwG3dTWD1oiKxi+jGYP7D1qUSc5vKhI=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "dc7ba6166e478804a9da6881aa48c45d300075cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-root_2": {
+      "locked": {
         "lastModified": 1671295174,
         "narHash": "sha256-5K+wdsB5TYSmI6HeexOMvJTZTBdXb9RbiFwXRtQkE3M=",
         "owner": "srid",
@@ -35,7 +50,7 @@
     },
     "mission-control": {
       "inputs": {
-        "flake-root": "flake-root",
+        "flake-root": "flake-root_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -105,6 +120,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs_2"
       }

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -33,36 +33,21 @@
         "type": "github"
       }
     },
-    "flake-root_2": {
-      "locked": {
-        "lastModified": 1671295174,
-        "narHash": "sha256-5K+wdsB5TYSmI6HeexOMvJTZTBdXb9RbiFwXRtQkE3M=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bb96b89f65d7c47457303f2385798a09f4a1dd5a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "mission-control": {
       "inputs": {
-        "flake-root": "flake-root_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1671301273,
-        "narHash": "sha256-+Nf+1E9zDucegqkauml04jQABXBpc89WN97jdBd+ogI=",
+        "lastModified": 1671388109,
+        "narHash": "sha256-XktBIVXG+NSw+QFyHNvIWv3WmkoGGYN8j5S3PkcINpc=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "3a8452c22d74ee913d05050eeab128d08cb8c6c5",
+        "rev": "9f725a4ffbf167fcc5240c2d8a72c3cda34320bc",
         "type": "github"
       },
       "original": {
         "owner": "Platonic-Systems",
+        "ref": "explicit-flake-root",
         "repo": "mission-control",
         "type": "github"
       }

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
-    mission-control.url = "github:Platonic-Systems/mission-control";
+    mission-control.url = "github:Platonic-Systems/mission-control/explicit-flake-root";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -9,7 +9,7 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
-        inputs.mission-control.flake-root
+        inputs.flake-root.flakeModule
         inputs.mission-control.flakeModule
       ];
       perSystem = { pkgs, lib, config, ... }: {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -2,12 +2,14 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-root.url = "github:srid/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
+        inputs.mission-control.flake-root
         inputs.mission-control.flakeModule
       ];
       perSystem = { pkgs, lib, config, ... }: {

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-root": {
-      "locked": {
-        "lastModified": 1671295174,
-        "narHash": "sha256-5K+wdsB5TYSmI6HeexOMvJTZTBdXb9RbiFwXRtQkE3M=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bb96b89f65d7c47457303f2385798a09f4a1dd5a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1671249438,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-root": "flake-root",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,9 @@
   description = "A `flake-parts` module for your Nix devshell scripts";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-root.url = "github:srid/flake-root";
   };
-  outputs = { self, nixpkgs, flake-root, ... }: {
-    flakeModule = import ./nix/flake-module.nix { inherit flake-root; };
+  outputs = { self, nixpkgs, ... }: {
+    flakeModule = ./nix/flake-module.nix;
     templates.default.path = (nixpkgs.lib.cleanSourceWith {
       src = ./example;
       filter = path: type: baseNameOf path == "flake.nix";

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,4 +1,3 @@
-{ flake-root }:
 { self, lib, flake-parts-lib, ... }:
 let
   inherit (flake-parts-lib)
@@ -8,10 +7,6 @@ let
     types;
 in
 {
-  _file = __curPos.file;
-  imports = [
-    flake-root.flakeModule
-  ];
   options = {
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }:


### PR DESCRIPTION
Otherwise, this will lead to conflicts if more than one flake-module imports it.