### PR TITLE
Remove mission-control from example's `flake.lock`

### DIFF
--- a/example/flake.lock
+++ b/example/flake.lock
@@ -33,24 +33,6 @@
         "type": "github"
       }
     },
-    "mission-control": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1671473115,
-        "narHash": "sha256-l6unCAV2CSgkW59WqAvOtcepADfkw862eok3KdPRZY8=",
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "rev": "8995493e2f139f25ffa29e8cb6f7ba9be9d23f1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1671249438,
@@ -85,28 +67,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1671249438,
-        "narHash": "sha256-5e+CcnbZA3/i2BRXbnzRS52Ly67MUNdZR+Zpbb2C65k=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "067bfc6c90a301572cec7da48f09c447a9a8eae0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
-        "mission-control": "mission-control",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,7 +1,0 @@
-{
-  "nodes": {
-    "root": {}
-  },
-  "root": "root",
-  "version": 7
-}

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1671249438,
-        "narHash": "sha256-5e+CcnbZA3/i2BRXbnzRS52Ly67MUNdZR+Zpbb2C65k=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "067bfc6c90a301572cec7da48f09c447a9a8eae0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,10 @@
 {
   description = "A `flake-parts` module for your Nix devshell scripts";
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  };
-  outputs = { self, nixpkgs, ... }: {
+  outputs = { self, ... }: {
     flakeModule = ./nix/flake-module.nix;
-    templates.default.path = (nixpkgs.lib.cleanSourceWith {
-      src = ./example;
-      filter = path: type: baseNameOf path == "flake.nix";
-    }).outPath;
+    templates.default = {
+      description = "Example flake using mission-control to provide scripts";
+      path =./example;
+    };
   };
 }


### PR DESCRIPTION
Because, in tests, we override it to parent flake anyway. And we do not want the user to accidentally end up using an outdated version of mission-control.

Consequently eliminate the top-level `flake.lock` as well.