### PR TITLE
Add `devShell` option, remove `installToDevShell`

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -27,9 +27,9 @@
             exec = pkgs.ponysay;
           };
         };
-        devShells.default =
-          let shell = pkgs.mkShell { };
-          in config.mission-control.installToDevShell shell;
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ config.mission-control.devShell ];
+        };
       };
     };
 }

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -94,7 +94,7 @@ in
               };
             };
             config = {
-              config.devShell = pkgs.mkShell {
+              devShell = pkgs.mkShell {
                 nativeBuildInputs = [ config.wrapper ];
                 shellHook = config.banner;
               };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -9,7 +9,7 @@ in
 {
   options = {
     perSystem = mkPerSystemOption
-      ({ config, self', inputs', pkgs, system, ... }:
+      (perSystem@{ config, self', inputs', pkgs, system, ... }:
         let
           scriptSubmodule = types.submodule {
             options = {
@@ -72,9 +72,8 @@ in
                   The generated wrapper script.
                 '';
                 default = import ./wrapper.nix {
-                  inherit pkgs lib;
-                  inherit (config) mission-control;
-                  flake-root = config.flake-root.package;
+                  inherit pkgs lib config;
+                  flake-root = perSystem.config.flake-root.package;
                 };
                 defaultText = lib.literalMD "generated package";
               };
@@ -83,7 +82,7 @@ in
                 description = lib.mdDoc ''
                   The generated shell banner.
                 '';
-                default = import ./banner.nix { inherit (config.mission-control) wrapper wrapperName; };
+                default = import ./banner.nix { inherit (config) wrapper wrapperName; };
                 defaultText = lib.literalMD "generated package";
               };
               devShell = mkOption {

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, mission-control, flake-root, ... }:
+{ pkgs, lib, config, flake-root, ... }:
 
 let
   mkCommand = name: v:
@@ -16,7 +16,7 @@ let
       commandsGrouped = lib.groupBy (a: a.meta.category) commands;
     in
     pkgs.writeShellApplication {
-      name = mission-control.wrapperName;
+      name = config.wrapperName;
       runtimeInputs = commands;
       text = ''
         showHelp () {
@@ -29,7 +29,7 @@ let
                     (map (drv: 
                       let name = builtins.baseNameOf (lib.getExe drv);
                           desc = drv.meta.description;
-                      in "  ${mission-control.wrapperName} " + name + "\t: " + desc
+                      in "  ${config.wrapperName} " + name + "\t: " + desc
                     ) commands 
                     ) + "' | ${lib.getExe pkgs.unixtools.column} -t -s ''$'\t'; "
               ) commandsGrouped)
@@ -66,7 +66,7 @@ let
       '';
     };
   wrapper =
-    (wrapCommands mission-control.scripts).overrideAttrs (oa: {
+    (wrapCommands config.scripts).overrideAttrs (oa: {
       meta.description = "Development scripts command";
       nativeBuildInputs = (oa.nativeBuildInputs or [ ]) ++ [ pkgs.installShellFiles ];
       # TODO: bash and zsh completion


### PR DESCRIPTION
`installToDevShell` is rather hacky. Instead, just expose a simple devShell that the user can compose using `inputsFrom` (see example).