### PR TITLE
Don't exit with error when running help

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -56,7 +56,7 @@ let
 
         if [ "$*" == "" ] || [ "$*" == "-h" ] || [ "$*" == "--help" ]; then
           showHelp
-          exit 1
+          exit 0
         else 
           FLAKE_ROOT="''$(${lib.getExe flake-root})"
           export FLAKE_ROOT


### PR DESCRIPTION
Changed exit status to success when running help to allow interoperability with direnv

When using direnv mission-control's help would run when moving into the directory. Help would exit with an error and thus direnv would this something went wrong when loading into the environment and back out. This caused direnv to be effectively useless when used in combination with mission-control.