### PR TITLE
fix trace warning for missing meta.mainProgram

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -3,7 +3,7 @@
 let
   mkCommand = name: v:
     let
-      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"'';};
+      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"''; };
     in
     drv.overrideAttrs (oa: {
       meta.description =

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -10,7 +10,7 @@ let
         if v.description == null then oa.meta.description or "No description" else v.description;
       meta.category = v.category;
       meta.mainProgram =
-        if v.mainProgram == null then oa.meta.name or "No name" else v.mainProgram;
+        if oa.meta.mainProgram == null then v.name or "No name" else v.mainProgram;
     });
   wrapCommands = spec:
     let

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -10,7 +10,7 @@ let
         if v.description == null then oa.meta.description or "No description" else v.description;
       meta.category = v.category;
       meta.mainProgram =
-        if oa.meta.mainProgram == null then v.name or "No name" else oa.meta.mainProgram;
+        oa.meta.mainProgram or v.name;
     });
   wrapCommands = spec:
     let

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -3,7 +3,7 @@
 let
   mkCommand = name: v:
     let
-      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"''; };
+      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"''; meta.mainProgram = if builtins.typeOf v.exec == "string" then v.exec else v.exec.meta.mainProgram};
     in
     drv.overrideAttrs (oa: {
       meta.description =

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -10,7 +10,7 @@ let
         if v.description == null then oa.meta.description or "No description" else v.description;
       meta.category = v.category;
       meta.mainProgram =
-        if oa.meta.mainProgram == null then v.name or "No name" else v.mainProgram;
+        if oa.meta.mainProgram == null then v.name or "No name" else oa.meta.mainProgram;
     });
   wrapCommands = spec:
     let

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -3,12 +3,14 @@
 let
   mkCommand = name: v:
     let
-      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"''; meta.mainProgram = if builtins.typeOf v.exec == "string" then v.exec else v.exec.meta.mainProgram};
+      drv = pkgs.writeShellApplication { inherit name; text = if builtins.typeOf v.exec == "string" then v.exec else ''${lib.getExe v.exec} "$@"'';};
     in
     drv.overrideAttrs (oa: {
       meta.description =
         if v.description == null then oa.meta.description or "No description" else v.description;
       meta.category = v.category;
+      meta.mainProgram =
+        if v.mainProgram == null then oa.meta.name or "No name" else v.mainProgram;
     });
   wrapCommands = spec:
     let


### PR DESCRIPTION
i barely have any idea of what i am doing as evidenced by my experimentation below, but i think this is right.

Without this change I get e.g.:
```
trace: warning: getExe: Package fmt does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when th
e assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control i
ts definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".

### ️🔨 Welcome to the Nix devshell ###

Available commands:

## Commands

  , fmt  : format the whole repo

(Run ',' to display this menu again)  
```

